### PR TITLE
fix: import path; purge: external dependencies;

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Nune
 
-A tensor based numerical engine.
+A tensor based numerical engine
 
-The numerical engine, or nune for short, is a package for performing numerical computation in Go, relying on generic tensors.
+The *nu*merical engi*ne*, or nune for short, is a package for performing numerical computation in Go, relying on generic tensors.
 This package provides facilities to manipulate and perform various operations on numerical data, and implements a numeric n-dimensional generic Tensor, along with a set of functions to create, manipulate and operate on that Tensor.
 
 ## Table of contents
@@ -23,7 +23,7 @@ Go v1.18 is currently only available in beta version, which can be downloaded [h
 After installing Go1.18, simply run this in your terminal...
 
 ```zsh
-go get github.com/vorduin/nune
+go get github.com/mattn/nune
 ```
 
 ... and you're good to Go!
@@ -69,7 +69,7 @@ import (
  "fmt"
  "math"
 
- "github.com/vorduin/nune"
+ "github.com/mattn/nune"
 )
 
 func main() {
@@ -161,4 +161,4 @@ Limitations that need to be fixed before this is a rock-stable library are the f
 
 ## License
 
-Nune has a BSD-style license, as found in the [LICENSE](https://github.com/vorduin/nune/blob/main/LICENSE) file.
+Nune has a BSD-style license, as found in the [LICENSE](./LICENSE) file.

--- a/attr.go
+++ b/attr.go
@@ -4,10 +4,6 @@
 
 package nune
 
-import (
-	"github.com/vorduin/slices"
-)
-
 // Ravel returns the Tensor's view in its data buffer.
 func (t Tensor[T]) Ravel() []T {
 	return t.data[t.offset : t.offset+t.Numel()]
@@ -29,7 +25,7 @@ func (t Tensor[T]) Numel() int {
 		return 1
 	}
 
-	return int(slices.Prod(t.shape))
+	return int(prod(t.shape))
 }
 
 // Rank returns the Tensor's rank
@@ -40,12 +36,12 @@ func (t Tensor[T]) Rank() int {
 
 // Shape returns a copy of the Tensor's shape.
 func (t Tensor[T]) Shape() []int {
-	return slices.Clone(t.shape)
+	return clone(t.shape)
 }
 
 // Stride returns a copy of the Tensor's stride scheme.
 func (t Tensor[T]) Stride() []int {
-	return slices.Clone(t.stride)
+	return clone(t.stride)
 }
 
 // Stride returns the Tensor's view offset in its data buffer.
@@ -81,7 +77,7 @@ func (t *Tensor[T]) Broadable(shape ...int) bool {
 	var s []int
 
 	if len(t.shape) < len(shape) {
-		s = slices.WithLen[int](len(shape))
+		s = make([]int, len(shape))
 		for i := 0; i < len(shape)-len(t.shape); i++ {
 			s[i] = 1
 		}

--- a/factory.go
+++ b/factory.go
@@ -7,8 +7,6 @@ package nune
 import (
 	"math"
 	"reflect"
-
-	"github.com/vorduin/slices"
 )
 
 // From returns a Tensor from the given backing - be it a numeric type,
@@ -75,14 +73,14 @@ func Full[T Number](x T, shape []int) Tensor[T] {
 		}
 	}
 
-	data := slices.WithLen[T](slices.Prod(shape))
+	data := make([]T, prod(shape))
 	for i := 0; i < len(data); i++ {
 		data[i] = T(x)
 	}
 
 	return Tensor[T]{
 		data:   data,
-		shape:  slices.Clone(shape),
+		shape:  clone(shape),
 		stride: configStride(shape),
 	}
 }
@@ -90,14 +88,14 @@ func Full[T Number](x T, shape []int) Tensor[T] {
 // FullLike returns a Tensor full with the given value and
 // resembling the other Tensor's shape.
 func FullLike[T Number, U Number](x T, other Tensor[U]) Tensor[T] {
-	data := slices.WithLen[T](other.Numel())
+	data := make([]T, other.Numel())
 	for i := 0; i < len(data); i++ {
 		data[i] = T(x)
 	}
 
 	return Tensor[T]{
 		data:   data,
-		shape:  slices.Clone(other.shape),
+		shape:  clone(other.shape),
 		stride: configStride(other.shape),
 	}
 }
@@ -116,8 +114,8 @@ func Zeros[T Number](shape ...int) Tensor[T] {
 	}
 
 	return Tensor[T]{
-		data:   slices.WithLen[T](int(slices.Prod(shape))),
-		shape:  slices.Clone(shape),
+		data:   make([]T, int(prod(shape))),
+		shape:  clone(shape),
 		stride: configStride(shape),
 	}
 }
@@ -126,8 +124,8 @@ func Zeros[T Number](shape ...int) Tensor[T] {
 // Tensor's shape.
 func ZerosLike[T Number, U Number](other Tensor[U]) Tensor[T] {
 	return Tensor[T]{
-		data:   slices.WithLen[T](other.Numel()),
-		shape:  slices.Clone(other.shape),
+		data:   make([]T, other.Numel()),
+		shape:  clone(other.shape),
 		stride: configStride(other.shape),
 	}
 }
@@ -161,7 +159,7 @@ func Range[T Number](start, end, step int) Tensor[T] {
 	l := int(math.Floor(d / math.Abs(float64(step)))) // length
 
 	i := 0
-	rng := slices.WithLen[T](l)
+	rng := make([]T, l)
 	for x := 0; x < l; x += 1 {
 		rng[i] = T(start + x*step)
 		i++

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
-module github.com/vorduin/nune
+module github.com/mattn/nune
 
-go 1.18
-
-require github.com/vorduin/slices v1.0.5
+go 1.23.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/vorduin/slices v1.0.5 h1:Da/TQyk+1xd6lBpVMx2PwMnplOP43pPiNVpGsg/nztg=
-github.com/vorduin/slices v1.0.5/go.mod h1:KN1SK0SrEsHQbrA48xrLKpr60I4+qfY89ABCxmX2h5w=

--- a/manip_test.go
+++ b/manip_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/vorduin/nune"
+	"github.com/mattn/nune"
 )
 
 func benchmarkMicro(b *testing.B, f func()) {

--- a/nune_test.go
+++ b/nune_test.go
@@ -8,21 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/vorduin/nune"
+	"github.com/mattn/nune"
 )
-
-func benchmarkMicro(b *testing.B, f func()) {
-	b.ResetTimer()
-
-	start := time.Now()
-	for i := 0; i < b.N; i++ {
-		f()
-	}
-	execTime := time.Since(start)
-
-	b.ReportMetric(0, "ns/op")
-	b.ReportMetric((1e6*execTime.Seconds())/float64(b.N), "μs/op")
-}
 
 func benchmarkMilli(b *testing.B, f func()) {
 	b.ResetTimer()
@@ -52,7 +39,7 @@ func benchmarkOp(b *testing.B, f func()) {
 
 	b.Run("1e7Float64ProcsN", func(b *testing.B) {
 		nune.EnvConfig.NumCPU = 0
-		
+
 		benchmarkMilli(b, func() {
 			f()
 		})

--- a/slices.go
+++ b/slices.go
@@ -1,0 +1,16 @@
+package nune
+
+// prod returns the product of the elements of the slice.
+func prod[T Number](s []T) T {
+	var prod T = 1
+	for i := 0; i < len(s); i++ {
+		prod *= s[i]
+	}
+	return prod
+}
+
+func clone[T any](src []T) []T {
+	dst := make([]T, len(src))
+	copy(dst, src)
+	return dst
+}

--- a/unwrap.go
+++ b/unwrap.go
@@ -6,8 +6,6 @@ package nune
 
 import (
 	"reflect"
-
-	"github.com/vorduin/slices"
 )
 
 // unwrapAnySlice attempts to recursively unwrap a slice
@@ -31,7 +29,7 @@ func unwrapAny[T Number](s []any, shape []int) ([]T, []int, error) {
 			}
 		}
 
-		p := slices.WithLen[any](len(s) * d)
+		p := make([]any, len(s)*d)
 		for i := 0; i < len(s); i++ {
 			r := reflect.ValueOf(s[i])
 			for j := 0; j < d; j++ {
@@ -93,7 +91,7 @@ func anyToNumeric[T Number](s ...any) []T {
 
 // numericToNumeric casts a numeric type to another numeric type.
 func numericToNumeric[T, U Number](s []any) []T {
-	ns := slices.WithLen[T](len(s))
+	ns := make([]T, len(s))
 	for i := 0; i < len(s); i++ {
 		ns[i] = T(s[i].(U))
 	}
@@ -104,31 +102,31 @@ func numericToNumeric[T, U Number](s []any) []T {
 // anyToTensor attempts to cast an interface
 // to a Tensor of the given numeric type.
 func anyToTensor[T Number](a any) (Tensor[T], bool) {
-	switch a.(type) {
+	switch a := a.(type) {
 	case Tensor[int]:
-		return Cast[T](a.(Tensor[int])), true
+		return Cast[T](a), true
 	case Tensor[int8]:
-		return Cast[T](a.(Tensor[int8])), true
+		return Cast[T](a), true
 	case Tensor[int16]:
-		return Cast[T](a.(Tensor[int16])), true
+		return Cast[T](a), true
 	case Tensor[int32]:
-		return Cast[T](a.(Tensor[int32])), true
+		return Cast[T](a), true
 	case Tensor[int64]:
-		return Cast[T](a.(Tensor[int64])), true
+		return Cast[T](a), true
 	case Tensor[uint]:
-		return Cast[T](a.(Tensor[uint])), true
+		return Cast[T](a), true
 	case Tensor[uint8]:
-		return Cast[T](a.(Tensor[uint8])), true
+		return Cast[T](a), true
 	case Tensor[uint16]:
-		return Cast[T](a.(Tensor[uint16])), true
+		return Cast[T](a), true
 	case Tensor[uint32]:
-		return Cast[T](a.(Tensor[uint32])), true
+		return Cast[T](a), true
 	case Tensor[uint64]:
-		return Cast[T](a.(Tensor[uint64])), true
+		return Cast[T](a), true
 	case Tensor[float32]:
-		return Cast[T](a.(Tensor[float32])), true
+		return Cast[T](a), true
 	case Tensor[float64]:
-		return Cast[T](a.(Tensor[float64])), true
+		return Cast[T](a), true
 	default:
 		return Tensor[T]{}, false
 	}

--- a/utils.go
+++ b/utils.go
@@ -7,14 +7,13 @@ package nune
 import (
 	"math"
 	"runtime"
-	"github.com/vorduin/slices"
 )
 
 // configStride returns the corresponding stride to the given shape.
 func configStride(shape []int) []int {
 	if len(shape) != 0 {
-		stride := slices.WithLen[int](len(shape))
-		stride[0] = slices.Prod(shape[1:])
+		stride := make([]int, len(shape))
+		stride[0] = prod(shape[1:])
 
 		for i := 1; i < len(shape); i++ {
 			stride[i] = stride[i-1] / shape[i]
@@ -26,7 +25,7 @@ func configStride(shape []int) []int {
 	return nil
 }
 
-// configCPU returns the number of CPU cores to use 
+// configCPU returns the number of CPU cores to use
 // depending on the data's size.
 func configCPU(size int) int {
 	if EnvConfig.NumCPU != 0 {

--- a/zip.go
+++ b/zip.go
@@ -5,8 +5,8 @@
 package nune
 
 import (
+	"reflect"
 	"sync"
-	"github.com/vorduin/slices"
 )
 
 // handleZip processes an elementwise operation accordingly.
@@ -38,7 +38,7 @@ func midwayBroadcast(s1, s2 []int) []int {
 	var s []int
 
 	if len(s1) < len(s2) {
-		s = slices.WithLen[int](len(s2))
+		s = make([]int, len(s2))
 		for i := 0; i < len(s2)-len(s1); i++ {
 			s[i] = 1
 		}
@@ -77,16 +77,16 @@ func (t Tensor[T]) Zip(other any, f func(T, T) T) Tensor[T] {
 		}
 	}
 
-	if !slices.Equal(t.shape, o.shape) {
-		if s := midwayBroadcast(o.shape, t.shape); t.Broadable(s...) && !slices.Equal(s, t.shape) {
+	if !reflect.DeepEqual(t.shape, o.shape) {
+		if s := midwayBroadcast(o.shape, t.shape); t.Broadable(s...) && !reflect.DeepEqual(s, t.shape) {
 			t = t.Broadcast(s...)
 		}
 
-		if s := midwayBroadcast(t.Shape(), o.Shape()); o.Broadable(s...) && !slices.Equal(s, o.shape) {
+		if s := midwayBroadcast(t.Shape(), o.Shape()); o.Broadable(s...) && !reflect.DeepEqual(s, o.shape) {
 			o = o.Broadcast(s...)
 		}
 
-		if !slices.Equal(t.shape, o.shape) {
+		if !reflect.DeepEqual(t.shape, o.shape) {
 			if EnvConfig.Interactive {
 				panic(ErrNotBroadable)
 			} else {


### PR DESCRIPTION
I was trying to import and noticed that the import path points to a repo which no longer exists and a user who's either deleted their account or changed their name and the repo's name.

After making that change I noticed that the library has an another dependency attributed to vorduin (namely, the `slices` repo) and decided to try and eliminate the dependency by porting the relevant semantics to internal components (see the `slices.go` file).  
In doing so, I found that the `slices` repo is still available via the golang cache, which enabled me to guarantee the semantic validity of the ports. An added benefit of removing this dependency is that we don't have to worry about running into supply chain attacks if this library ever gains popularity.
